### PR TITLE
Append fields before files in FormData of request

### DIFF
--- a/src/request/index.js
+++ b/src/request/index.js
@@ -18,13 +18,15 @@ export default ({ request, files, instance, progress }) =>
     if (!request.fileName && !request.fields) return xhr.send(files[0]);
 
     var formData = new FormData();
-    Array.from(files).forEach(file =>
-      formData.append(request.fileName || 'file', file));
 
+    //append fields first, fixes https://github.com/expressjs/multer/issues/322
     if (request.fields) {
       Object.keys(request.fields).forEach(field =>
         formData.append(field, request.fields[field]));
     }
+
+    Array.from(files).forEach(file =>
+      formData.append(request.fileName || 'file', file));
 
     xhr.send(formData);
   });


### PR DESCRIPTION
Addresses issues https://github.com/expressjs/multer/issues/322, https://github.com/expressjs/multer/issues/146. which can cause headaches in asynchronous request handling.

---

>As you can see in your request payload, the file is sent before the classId field, and thus there is no way for multer to know about classId when it's handling the file.
>
>I wish I had an easy solution for you but the only thing I can recommend is to manually reorder the fields with javascript to make sure that fields are sent before files.

---

>Thats how your browser works, it's impossible to fix in multer.
>
>A fix for this is to use javascript on the client side to catch the submit event and instead submit using FormData and ordering the fields so that the input data is before any files.
